### PR TITLE
Add gRPC support for worker communication

### DIFF
--- a/Poneglyph/CMakeLists.txt
+++ b/Poneglyph/CMakeLists.txt
@@ -5,6 +5,45 @@ project(Poneglyph LANGUAGES CXX)
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+# ---- gRPC / Protobuf ----
+find_package(Protobuf REQUIRED)
+find_package(gRPC REQUIRED)
+
+# Paths
+set(PROTO_DIR ${CMAKE_CURRENT_SOURCE_DIR}/proto)
+set(PROTO_FILE ${PROTO_DIR}/gridmr.proto)
+set(GEN_DIR ${CMAKE_CURRENT_BINARY_DIR}/generated)
+file(MAKE_DIRECTORY ${GEN_DIR})
+
+# Generate protobuf sources
+add_custom_command(
+        OUTPUT ${GEN_DIR}/gridmr.pb.cc ${GEN_DIR}/gridmr.pb.h
+        COMMAND protobuf::protoc
+        ARGS --cpp_out ${GEN_DIR} -I ${PROTO_DIR} ${PROTO_FILE}
+        DEPENDS ${PROTO_FILE}
+)
+
+# Generate gRPC sources
+add_custom_command(
+        OUTPUT ${GEN_DIR}/gridmr.grpc.pb.cc ${GEN_DIR}/gridmr.grpc.pb.h
+        COMMAND protobuf::protoc
+        ARGS --grpc_out ${GEN_DIR} --plugin=protoc-gen-grpc=$<TARGET_FILE:gRPC::grpc_cpp_plugin> -I ${PROTO_DIR} ${PROTO_FILE}
+        DEPENDS ${PROTO_FILE}
+)
+
+add_library(gridmr_proto
+        ${GEN_DIR}/gridmr.pb.cc
+        ${GEN_DIR}/gridmr.grpc.pb.cc
+)
+
+target_include_directories(gridmr_proto PUBLIC ${GEN_DIR})
+target_link_libraries(gridmr_proto PUBLIC protobuf::libprotobuf gRPC::grpc++)
+
+# ---- MQTT (existing) ----
+find_library(PAHO_CPP_LIB paho-mqttpp3 REQUIRED)
+find_library(PAHO_C_LIB paho-mqtt3a REQUIRED)
+
+# ---- Worker binary ----
 add_executable(Poneglyph
         main.cpp
         model/http.hpp
@@ -12,13 +51,16 @@ add_executable(Poneglyph
         model/worker.hpp
         core/worker.cpp
         telemetry/mqtt.hpp
-        telemetry/mqtt.cpp)
+        telemetry/mqtt.cpp
+        rpc/grpc_client.hpp
+)
 
 target_include_directories(Poneglyph PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}
         ${CMAKE_CURRENT_SOURCE_DIR}/model
         ${CMAKE_CURRENT_SOURCE_DIR}/core
         ${CMAKE_CURRENT_SOURCE_DIR}/telemetry
+        ${CMAKE_CURRENT_SOURCE_DIR}/rpc
 )
 
 # Link Paho MQTT C++ and C (Debian/Ubuntu packages provide these)
@@ -29,4 +71,11 @@ if (NOT PAHO_CPP_LIB OR NOT PAHO_C_LIB)
     message(FATAL_ERROR "Paho MQTT libraries not found. Install libpaho-mqttpp3-dev and libpaho-mqtt-dev.")
 endif ()
 
-target_link_libraries(Poneglyph PRIVATE ${PAHO_CPP_LIB} ${PAHO_C_LIB})
+target_link_libraries(Poneglyph
+        PRIVATE
+        gridmr_proto
+        gRPC::grpc++
+        protobuf::libprotobuf
+        ${PAHO_CPP_LIB}
+        ${PAHO_C_LIB}
+)

--- a/Poneglyph/Dockerfile
+++ b/Poneglyph/Dockerfile
@@ -1,35 +1,38 @@
 FROM debian:bookworm-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential cmake curl python3 ca-certificates \
-    git libssl-dev \
+    build-essential cmake curl python3 ca-certificates git \
+    autoconf libtool pkg-config libssl-dev \
  && rm -rf /var/lib/apt/lists/*
 
-# Build and install Paho MQTT C library
+# --- Build & install gRPC + Protobuf (local) ---
 WORKDIR /usr/src
+RUN git clone --recurse-submodules -b v1.74.0 --depth 1 --shallow-submodules https://github.com/grpc/grpc
+WORKDIR /usr/src/grpc
+RUN mkdir -p cmake/build && cd cmake/build && \
+    cmake -DgRPC_INSTALL=ON -DgRPC_BUILD_TESTS=OFF -DCMAKE_CXX_STANDARD=20 -DCMAKE_INSTALL_PREFIX=/usr/local ../.. && \
+    make -j4 && make install && ldconfig
+WORKDIR /usr/src
+RUN rm -rf grpc
+
+# --- Paho MQTT (as you already had) ---
 RUN git clone https://github.com/eclipse/paho.mqtt.c.git && \
     cd paho.mqtt.c && \
     cmake -Bbuild -H. -DPAHO_WITH_SSL=TRUE -DPAHO_BUILD_DOCUMENTATION=FALSE -DPAHO_BUILD_SAMPLES=FALSE && \
-    cmake --build build/ --target install && \
-    ldconfig && \
-    cd .. && rm -rf paho.mqtt.c
+    cmake --build build/ --target install && ldconfig && cd .. && rm -rf paho.mqtt.c
 
-# Build and install Paho MQTT C++ library
 RUN git clone https://github.com/eclipse/paho.mqtt.cpp.git && \
     cd paho.mqtt.cpp && \
     cmake -Bbuild -H. -DPAHO_WITH_SSL=TRUE -DPAHO_BUILD_DOCUMENTATION=FALSE -DPAHO_BUILD_SAMPLES=FALSE && \
-    cmake --build build/ --target install && \
-    ldconfig && \
-    cd .. && rm -rf paho.mqtt.cpp
+    cmake --build build/ --target install && ldconfig && cd .. && rm -rf paho.mqtt.cpp
 
+# --- Build worker ---
 WORKDIR /app
 COPY . /app
+RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && cmake --build build -j
 
-RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Release && \
-    cmake --build build -j
-
+# Defaults
 ENV PONEGLYPH_MASTER_URL=http://master:8080
-# Optional MQTT envs; compose will override
-# ENV MQTT_BROKER=tcp://mqtt:1883 MQTT_USERNAME=admin MQTT_PASSWORD=public
-
+ENV PONEGLYPH_USE_GRPC=1
+ENV PONEGLYPH_MASTER_GRPC=master:50051
 CMD ["./build/Poneglyph"]

--- a/Poneglyph/core/worker.cpp
+++ b/Poneglyph/core/worker.cpp
@@ -2,6 +2,8 @@
 #include "model/http.hpp"
 #include "model/json.hpp"
 #include "telemetry/mqtt.hpp"
+#include "gridmr.grpc.pb.h"
+#include "rpc/grpc_client.hpp"
 
 #include <chrono>
 #include <iostream>
@@ -9,8 +11,9 @@
 #include <thread>
 
 Worker::Worker(std::string masterUrl,
-               std::unique_ptr<telemetry::MqttClientManager> mqttClient)
-    : master(std::move(masterUrl)), mqtt(std::move(mqttClient)) {
+               std::unique_ptr<telemetry::MqttClientManager> mqttClient,
+               std::unique_ptr<MasterGrpcClient> grpcClient)
+    : master(std::move(masterUrl)), mqtt(std::move(mqttClient)), grpc(std::move(grpcClient)) {
 }
 
 long long Worker::now_ms() {
@@ -19,29 +22,39 @@ long long Worker::now_ms() {
 }
 
 void Worker::registerSelf() {
-    // Obtener métricas del sistema para el registro
     auto [cpuUsage, memUsage] = getSystemMetrics();
 
-    std::ostringstream registrationPayload;
-    registrationPayload << "{"
-            << "\"name\":\"poneglyph-worker\","
-            << "\"capacity\":2," // Capacidad de tareas concurrentes
-            << "\"cpu_cores\":4," // Número de cores simulados
-            << "\"memory_mb\":8192," // 8GB de memoria simulada
-            << "\"cpu_usage\":" << cpuUsage << ","
-            << "\"memory_usage\":" << memUsage
-            << "}";
+    // Prefer gRPC if available
+    if (grpc) {
+        std::string wid;
+        int poll_ms = 1000;
+        bool ok = grpc->RegisterWorker("poneglyph-worker", /*capacity*/2, wid, &poll_ms);
+        if (ok && !wid.empty()) {
+            workerId = wid;
+            std::cout << "[gRPC] Registered as " << workerId << " (poll=" << poll_ms << "ms)\n";
+        } else {
+            std::cerr << "[gRPC] Register failed, falling back to HTTP.\n";
+        }
+    }
 
-    std::string reg = http_post_json(master + "/api/workers/register", registrationPayload.str());
-    std::cout << "Registration response: " << reg << std::endl;
-    workerId = get_json_str(reg, "worker_id");
-    std::cout << "Registered as " << workerId << std::endl;
+    if (workerId.empty()) {
+        // HTTP fallback
+        std::ostringstream registrationPayload;
+        registrationPayload << "{"
+                << "\"name\":\"poneglyph-worker\","
+                << "\"capacity\":2," // Capacidad de tareas concurrentes
+                << "\"cpu_usage\":" << cpuUsage << ","
+                << "\"memory_usage\":" << memUsage
+                << "}";
+        std::string reg = http_post_json(master + "/api/workers/register", registrationPayload.str());
+        workerId = get_json_str(reg, "worker_id");
+        std::cout << "[HTTP] Registered as " << workerId << std::endl;
+    }
 
     if (mqtt) {
         std::ostringstream j;
         j << "{\"workerId\":\"" << workerId << "\","
                 << "\"name\":\"poneglyph-worker\",\"capacity\":2,"
-                << "\"cpu_cores\":4,\"memory_mb\":8192,"
                 << "\"ts\":" << now_ms() << "}";
         mqtt->publish_json("gridmr/worker/registered", j.str());
     }
@@ -173,11 +186,30 @@ void Worker::handleReduce(const std::string &taskJson) {
 }
 
 int Worker::run() {
-    std::cout << "Poneglyph Worker starting. Master=" << master << std::endl;
+    std::cout << "Poneglyph Worker starting. Master(HTTP)=" << master
+            << (grpc ? "  [gRPC enabled]" : "  [gRPC disabled]") << std::endl;
+
     registerSelf();
     startHeartbeat();
 
     while (true) {
+        if (grpc) {
+            gridmr::TaskAssignment ta;
+            if (!grpc->NextTask(workerId, ta)) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(800));
+                continue;
+            }
+            if (!ta.has_task()) {
+                std::this_thread::sleep_for(std::chrono::milliseconds(800));
+                continue;
+            }
+            if (ta.has_map()) handleMapGrpc(ta.map());
+            else if (ta.has_reduce()) handleReduceGrpc(ta.reduce());
+            else std::this_thread::sleep_for(std::chrono::milliseconds(300));
+            continue;
+        }
+
+        // HTTP fallback (existing behavior)
         std::string task = http_get(master + "/api/tasks/next?workerId=" + workerId);
         if (task.empty()) {
             std::this_thread::sleep_for(std::chrono::milliseconds(800));
@@ -188,6 +220,93 @@ int Worker::run() {
         else if (type == "REDUCE") handleReduce(task);
         else std::this_thread::sleep_for(std::chrono::milliseconds(300));
     }
-    // unreachable
-    // return 0;
+}
+
+
+void Worker::handleMapGrpc(const gridmr::MapTask &mt) {
+    // Map script: prefer embedded; else fetch via HTTP fallback URL
+    if (!mt.map_script().empty()) {
+        std::string s(mt.map_script().begin(), mt.map_script().end());
+        save_file("map.py", s);
+    } else {
+        save_file("map.py", http_get(master + mt.map_url()));
+    }
+    // input
+    save_file("input.txt", mt.input_chunk());
+
+    // run
+    sh("python3 map.py input.txt > map.out");
+    std::string kv = sh("cat map.out");
+    if (kv.empty()) std::cerr << "[WARN] Mapper produced 0 lines for " << mt.task_id() << std::endl;
+
+    if (grpc) {
+        if (!grpc->CompleteMap(workerId, mt.task_id(), mt.job_id(), kv)) {
+            std::cerr << "[gRPC] CompleteMap failed\n";
+        }
+    } else {
+        // Shouldn't happen, but keep symmetry
+        std::ostringstream payload;
+        payload << "{\"worker_id\":\"" << workerId << "\","
+                << "\"task_id\":\"" << mt.task_id() << "\","
+                << "\"job_id\":\"" << mt.job_id() << "\","
+                << "\"type\":\"MAP\","
+                << "\"kv_lines\":\"";
+        for (char c: kv) {
+            if (c == '\\' || c == '\"') payload << '\\' << c;
+            else if (c == '\n') payload << "\\n";
+            else if (c == '\t') payload << "\\t";
+            else payload << c;
+        }
+        payload << "\"}";
+        http_post_json(master + "/api/tasks/complete", payload.str());
+    }
+
+    if (mqtt) {
+        std::ostringstream j;
+        j << "{\"taskId\":\"" << mt.task_id() << "\",\"jobId\":\"" << mt.job_id()
+                << "\",\"ts\":" << now_ms() << "}";
+        mqtt->publish_json("gridmr/worker/" + workerId + "/map/completed", j.str());
+    }
+}
+
+void Worker::handleReduceGrpc(const gridmr::ReduceTask &rt) {
+    if (!rt.reduce_script().empty()) {
+        std::string s(rt.reduce_script().begin(), rt.reduce_script().end());
+        save_file("reduce.py", s);
+    } else {
+        save_file("reduce.py", http_get(master + rt.reduce_url()));
+    }
+    save_file("reduce_in.txt", rt.kv_lines());
+
+    sh("python3 reduce.py reduce_in.txt > reduce.out");
+    std::string out = sh("cat reduce.out");
+    if (out.empty()) std::cerr << "[WARN] Reducer produced 0 lines for " << rt.task_id() << std::endl;
+
+    if (grpc) {
+        if (!grpc->CompleteReduce(workerId, rt.task_id(), rt.job_id(), out)) {
+            std::cerr << "[gRPC] CompleteReduce failed\n";
+        }
+    } else {
+        std::ostringstream payload;
+        payload << "{\"worker_id\":\"" << workerId << "\","
+                << "\"task_id\":\"" << rt.task_id() << "\","
+                << "\"job_id\":\"" << rt.job_id() << "\","
+                << "\"type\":\"REDUCE\","
+                << "\"output\":\"";
+        for (char c: out) {
+            if (c == '\\' || c == '\"') payload << '\\' << c;
+            else if (c == '\n') payload << "\\n";
+            else if (c == '\t') payload << "\\t";
+            else payload << c;
+        }
+        payload << "\"}";
+        http_post_json(master + "/api/tasks/complete", payload.str());
+    }
+
+    if (mqtt) {
+        std::ostringstream j;
+        j << "{\"taskId\":\"" << rt.task_id() << "\",\"jobId\":\"" << rt.job_id()
+                << "\",\"ts\":" << now_ms() << "}";
+        mqtt->publish_json("gridmr/worker/" + workerId + "/reduce/completed", j.str());
+    }
 }

--- a/Poneglyph/main.cpp
+++ b/Poneglyph/main.cpp
@@ -1,14 +1,27 @@
 #include "model/worker.hpp"
 #include "telemetry/mqtt.hpp"
+#include "rpc/grpc_client.hpp"
+
 #include <cstdlib>
-#include <string>
 #include <memory>
+#include <string>
+
+static std::string getenv_or(const char *k, const char *dflt) {
+    const char *v = std::getenv(k);
+    return v ? std::string(v) : std::string(dflt);
+}
 
 int main() {
-    std::string master = std::getenv("PONEGLYPH_MASTER_URL")
-                             ? std::getenv("PONEGLYPH_MASTER_URL")
-                             : "http://localhost:8080";
+    std::string master_http = getenv_or("PONEGLYPH_MASTER_URL", "http://master:8080");
     auto mqtt = telemetry::MqttClientManager::from_env_or_null();
-    Worker w(master, std::move(mqtt));
+
+    std::unique_ptr<MasterGrpcClient> grpcClient;
+    const std::string use_grpc = getenv_or("PONEGLYPH_USE_GRPC", "0");
+    if (use_grpc == "1" || use_grpc == "true" || use_grpc == "TRUE") {
+        std::string grpc_addr = getenv_or("PONEGLYPH_MASTER_GRPC", "master:50051");
+        grpcClient = std::make_unique<MasterGrpcClient>(grpc_addr);
+    }
+
+    Worker w(master_http, std::move(mqtt), std::move(grpcClient));
     return w.run();
 }

--- a/Poneglyph/model/worker.hpp
+++ b/Poneglyph/model/worker.hpp
@@ -6,18 +6,22 @@ namespace telemetry {
     class MqttClientManager;
 }
 
+class MasterGrpcClient; // fwd
+
 class Worker {
 public:
     explicit Worker(std::string masterUrl,
-                    std::unique_ptr<telemetry::MqttClientManager> mqtt = nullptr);
+                    std::unique_ptr<telemetry::MqttClientManager> mqtt = nullptr,
+                    std::unique_ptr<MasterGrpcClient> grpc = nullptr);
 
-    int run(); // main loop
+    int run();
 
 private:
-    std::string master;
+    std::string master; // HTTP base (e.g., http://master:8080)
     std::string workerId;
 
     std::unique_ptr<telemetry::MqttClientManager> mqtt;
+    std::unique_ptr<MasterGrpcClient> grpc; // if present, use gRPC
 
     void registerSelf();
 
@@ -27,7 +31,13 @@ private:
 
     std::pair<double, double> getSystemMetrics();
 
+    // HTTP paths (existing)
     void handleMap(const std::string &taskJson);
 
     void handleReduce(const std::string &taskJson);
+
+    // gRPC paths
+    void handleMapGrpc(const gridmr::MapTask &mt);
+
+    void handleReduceGrpc(const gridmr::ReduceTask &rt);
 };

--- a/Poneglyph/proto/gridmr.proto
+++ b/Poneglyph/proto/gridmr.proto
@@ -1,0 +1,50 @@
+syntax = "proto3";
+
+package gridmr;
+
+option java_package = "gridmr";
+option java_multiple_files = true;
+
+// ---- Worker lifecycle ----
+message WorkerRegisterRequest { string name = 1; int32 capacity = 2; }
+message WorkerRegisterResponse { string worker_id = 1; int32 poll_interval_ms = 2; }
+
+// ---- Task dispatch ----
+message NextTaskRequest { string worker_id = 1; }
+
+message MapTask {
+  string task_id = 1;
+  string job_id = 2;
+  string input_chunk = 3;
+  string map_url = 4;  // HTTP fallback
+  int32  reducers = 5;
+  bytes  map_script = 6; // optional
+}
+
+message ReduceTask {
+  string task_id = 1;
+  string job_id = 2;
+  int32  partition_index = 3;
+  string reduce_url = 4; // HTTP fallback
+  string kv_lines = 5;
+  bytes  reduce_script = 6; // optional
+}
+
+message TaskAssignment {
+  bool has_task = 1;
+  oneof task { MapTask map = 2; ReduceTask reduce = 3; }
+}
+
+// ---- Completion ----
+message CompleteMapRequest { string worker_id = 1; string task_id = 2; string job_id = 3; string kv_lines = 4; }
+message CompleteReduceRequest { string worker_id = 1; string task_id = 2; string job_id = 3; string output = 4; }
+
+message Ack { bool ok = 1; }
+
+// ---- Service ----
+service Master {
+  rpc Register       (WorkerRegisterRequest) returns (WorkerRegisterResponse);
+  rpc NextTask       (NextTaskRequest)       returns (TaskAssignment);
+  rpc CompleteMap    (CompleteMapRequest)    returns (Ack);
+  rpc CompleteReduce (CompleteReduceRequest) returns (Ack);
+}

--- a/Poneglyph/rpc/grpc_client.hpp
+++ b/Poneglyph/rpc/grpc_client.hpp
@@ -1,0 +1,68 @@
+#pragma once
+#include <memory>
+#include <string>
+#include <grpcpp/grpcpp.h>
+#include "gridmr.grpc.pb.h"
+
+class MasterGrpcClient {
+public:
+    explicit MasterGrpcClient(const std::string &addr)
+        : channel_(grpc::CreateChannel(addr, grpc::InsecureChannelCredentials())),
+          stub_(gridmr::Master::NewStub(channel_)) {
+    }
+
+    bool RegisterWorker(const std::string &name, int capacity, std::string &out_worker_id, int *poll_ms = nullptr) {
+        gridmr::WorkerRegisterRequest req;
+        req.set_name(name);
+        req.set_capacity(capacity);
+        gridmr::WorkerRegisterResponse resp;
+        grpc::ClientContext ctx;
+        auto status = stub_->Register(&ctx, req, &resp);
+        if (!status.ok()) return false;
+        out_worker_id = resp.worker_id();
+        if (poll_ms) *poll_ms = resp.poll_interval_ms();
+        return true;
+    }
+
+    bool NextTask(const std::string &worker_id, gridmr::TaskAssignment &out) {
+        gridmr::NextTaskRequest req;
+        req.set_worker_id(worker_id);
+        grpc::ClientContext ctx;
+        auto status = stub_->NextTask(&ctx, req, &out);
+        return status.ok();
+    }
+
+    bool CompleteMap(const std::string &worker_id,
+                     const std::string &task_id,
+                     const std::string &job_id,
+                     const std::string &kv_lines) {
+        gridmr::CompleteMapRequest req;
+        req.set_worker_id(worker_id);
+        req.set_task_id(task_id);
+        req.set_job_id(job_id);
+        req.set_kv_lines(kv_lines);
+        gridmr::Ack ack;
+        grpc::ClientContext ctx;
+        auto status = stub_->CompleteMap(&ctx, req, &ack);
+        return status.ok() && ack.ok();
+    }
+
+    bool CompleteReduce(const std::string &worker_id,
+                        const std::string &task_id,
+                        const std::string &job_id,
+                        const std::string &output) {
+        gridmr::CompleteReduceRequest req;
+        req.set_worker_id(worker_id);
+        req.set_task_id(task_id);
+        req.set_job_id(job_id);
+        req.set_output(output);
+        gridmr::Ack ack;
+        grpc::ClientContext ctx;
+        auto status = stub_->CompleteReduce(&ctx, req, &ack);
+        return status.ok() && ack.ok();
+    }
+
+private:
+    std::shared_ptr<grpc::Channel> channel_;
+    std::unique_ptr<gridmr::Master::Stub> stub_;
+};

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,8 @@ services:
       MQTT_BROKER: tcp://mqtt:1883
       MQTT_USERNAME: admin
       MQTT_PASSWORD: public
-
+      PONEGLYPH_USE_GRPC: "1"
+      PONEGLYPH_MASTER_GRPC: master:50051
 
   client:
     build: ./Clover


### PR DESCRIPTION
- Integrated gRPC functionality into the Poneglyph worker, allowing for task registration and assignment via gRPC.
- Updated Dockerfile to install gRPC and Protobuf dependencies.
- Modified CMakeLists.txt to include gRPC and Protobuf in the build process.
- Enhanced the Worker class to handle both HTTP and gRPC communication for task management.
- Added new proto definitions for worker registration and task assignment.
- Updated main.cpp and worker.cpp to utilize gRPC for task handling and registration, with fallback to HTTP if gRPC is unavailable.
- Introduced a new MasterGrpcClient class to encapsulate gRPC client operations.